### PR TITLE
Adding new API fields to the SDK method.

### DIFF
--- a/src/beproduct/_material.py
+++ b/src/beproduct/_material.py
@@ -67,10 +67,17 @@ class Material(UploadMixin, AttributesMixin, AppsMixin, CommentsMixin,
                         color['fields'][field_id]
                     })
 
-                colorway_fields.append({
+                api_colorway = {
                     'id': color['id'],
                     'fields': unwound_colorway_fields
-                })
+                }
+
+                if 'imageHeaderId' in color:
+                    api_colorway['imageHeaderId'] = color['imageHeaderId']
+                if  'unlinkImage' in color:
+                    api_colorway['unlinkImage'] = color['unlinkImage']
+
+                colorway_fields.append(api_colorway)
 
         return self.client.raw_api.post(
             f"Material/Header/{header_id}/Update", {
@@ -118,10 +125,17 @@ class Material(UploadMixin, AttributesMixin, AppsMixin, CommentsMixin,
                         color['fields'][field_id]
                     })
 
-                colorway_fields.append({
+                api_colorway = {
                     'id': color['id'],
                     'fields': unwound_colorway_fields
-                })
+                }
+
+                if 'imageHeaderId' in color:
+                    api_colorway['imageHeaderId'] = color['imageHeaderId']
+                if  'unlinkImage' in color:
+                    api_colorway['unlinkImage'] = color['unlinkImage']
+
+                colorway_fields.append(api_colorway)
 
         return self.client.raw_api.post(
             f"Material/Header/Create?folderId={folder_id}", {

--- a/src/beproduct/_style.py
+++ b/src/beproduct/_style.py
@@ -78,9 +78,17 @@ class Style(
                         {"id": field_id, "value": color["fields"][field_id]}
                     )
 
-                colorway_fields.append(
-                    {"id": color["id"], "fields": unwound_colorway_fields}
-                )
+                api_colorway = {
+                    'id': color['id'],
+                    'fields': unwound_colorway_fields
+                }
+
+                if 'imageHeaderId' in color:
+                    api_colorway['imageHeaderId'] = color['imageHeaderId']
+                if 'unlinkImage' in color:
+                    api_colorway['unlinkImage'] = color['unlinkImage']
+
+                colorway_fields.append(api_colorway)
 
         return self.client.raw_api.post(
             f"Style/Header/{header_id}/Update",
@@ -119,9 +127,17 @@ class Style(
                         {"id": field_id, "value": color["fields"][field_id]}
                     )
 
-                colorway_fields.append(
-                    {"id": color["id"], "fields": unwound_colorway_fields}
-                )
+                api_colorway = {
+                    'id': color['id'],
+                    'fields': unwound_colorway_fields
+                }
+
+                if 'imageHeaderId' in color:
+                    api_colorway['imageHeaderId'] = color['imageHeaderId']
+                if 'unlinkImage' in color:
+                    api_colorway['unlinkImage'] = color['unlinkImage']
+
+                colorway_fields.append(api_colorway)
 
         return self.client.raw_api.post(
             f"Style/Header/Create?folderId={folder_id}",


### PR DESCRIPTION
Since the last updates to SDK, Material Create API has obtained new fields WRT to the colorways.

To make the change as non-breaking as possible, this PR adds new fields to existing request only if they are already present in the incoming message.